### PR TITLE
Add support for single-line and block-level comments

### DIFF
--- a/devicetree.YAML-tmPreferences
+++ b/devicetree.YAML-tmPreferences
@@ -1,0 +1,31 @@
+# [PackageDev] target_format: plist, ext: tmPreferences
+#
+#  Copyright 2017 Josh Watts, original idea by Tutu Ajayi
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+# This adds support line and block comments
+#
+name: Devicetree
+scope: source.devicetree
+fileTypes: [dts, dtsi]
+uuid: f8106bbd-6378-40f2-b68e-d374441a0b9d
+settings:
+  shellVariables:
+  - name: TM_COMMENT_START
+    value: '// '
+  - name: TM_COMMENT_START_2
+    value: /*
+  - name: TM_COMMENT_END_2
+    value: '*/'

--- a/devicetree.tmPreferences
+++ b/devicetree.tmPreferences
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array>
+		<string>dts</string>
+		<string>dtsi</string>
+	</array>
+	<key>name</key>
+	<string>Devicetree</string>
+	<key>scope</key>
+	<string>source.devicetree</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>/*</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>*/</string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>f8106bbd-6378-40f2-b68e-d374441a0b9d</string>
+</dict>
+</plist>


### PR DESCRIPTION
This is a direct implementation of #2 in the requested YAML format. Kudos to @tajayi for the original implementation.